### PR TITLE
Exit when no valid arguments are given.

### DIFF
--- a/tflite2addpad.sh
+++ b/tflite2addpad.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-echo "usage: ./tflite2addpad.sh  xxx.tflite"
+if [ -z "$1" ]; then
+    echo "usage: $0 xxx.tflite"
+    exit
+fi
 name=`echo $1 | cut -d '.' -f 1`
 name=$name.pb
 ncc -i tflite -o addpad  $1 $name

--- a/tflite2kmodel.sh
+++ b/tflite2kmodel.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-echo "uasge: ./tflite2kmodel.sh xxx.tflite"
+if [ -z "$1" ]; then
+    echo "uasge: $0 xxx.tflite"
+    exit
+fi
 name=`echo $1 | cut -d '.' -f 1`
 name=$name.kmodel
 ./ncc/ncc -i tflite -o k210model --dataset images $1 ./$name

--- a/tflite2pb.sh
+++ b/tflite2pb.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-echo "usage: ./tflite2pb.sh xxx.tflite"
+if [ -z "$1" ]; then
+    echo "usage: $0 xxx.tflite"
+    exit
+fi
 name=`echo $1 | cut -d '.' -f 1`
 name=$name.pb
 ncc -i tflite -o tf $1 $name


### PR DESCRIPTION
I think the common pattern of linux commands is not to show the usage help message when a valid arguments are given and the command does some actual work.
Additionally, when the $1 were empty, the remaining part of the script would either fail or work in an unintended way, thus it would be better to stop the execution.